### PR TITLE
updates to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 # Dependencies
 
 - `bash`, `curl`, `tar`: generic POSIX utilities.
+- `jq`: for parsing json
 - `SOME_ENV_VAR`: set this environment variable in your shell config to load the correct version of tool x.
 
 # Install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Plugin:
 ```shell
 asdf plugin add ansible
 # or
-asdf plugin add https://github.com/Bleacks/asdf-ansible.git
+asdf plugin add ansible https://github.com/Bleacks/asdf-ansible.git
 ```
 
 ansible:


### PR DESCRIPTION
addresses #1

per https://github.com/asdf-vm/asdf-plugins the correct syntax (as of the time of this writing) to add using the repo is:
```
asdf plugin add <name> <git_url>
```

also added additional undocumented requirement for jq
```
~/.asdf/plugins/ansible/bin/../lib/utils.bash: line 30: jq: command not found
```
