### PR TITLE
fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@
 Plugin:
 
 ```shell
-asdf plugin add ansible
-# or
-asdf plugin add ansible https://github.com/Bleacks/asdf-ansible.git
+asdf plugin add ansible https://github.com/Bleacks/asdf-ansible-plugin.git
 ```
 
 ansible:


### PR DESCRIPTION
The text name of the repository was wrong. 
The plugin is also not in the central repository so a asdf plugin install ansible will not work.